### PR TITLE
gralloc: Fix custom content metadata region support

### DIFF
--- a/gralloc/gr_priv_handle.h
+++ b/gralloc/gr_priv_handle.h
@@ -132,6 +132,9 @@ struct private_handle_t {
 #ifdef GRALLOC_HANDLE_HAS_RESERVED_SIZE
   unsigned int reserved_size;
 #endif
+#ifdef GRALLOC_HANDLE_HAS_CUSTOM_CONTENT_MD_RESERVED_SIZE
+  unsigned int custom_content_md_reserved_size;
+#endif
 #ifdef __cplusplus
   static const int kNumFds = 2;
   static const int kMagic = 'gmsm';
@@ -163,6 +166,9 @@ struct private_handle_t {
         gpuaddr(0)
 #ifdef GRALLOC_HANDLE_HAS_RESERVED_SIZE
         ,reserved_size(0)
+#endif
+#ifdef GRALLOC_HANDLE_HAS_CUSTOM_CONTENT_MD_RESERVED_SIZE
+        ,custom_content_md_reserved_size(0)
 #endif
   {
     version = static_cast<int>(sizeof(native_handle));


### PR DESCRIPTION
Update gr_priv_handle.h struct to match QtiGrallocPriv.h

Change-Id: I95c82a6ba605e5abc748594ba441493f0e5633ea